### PR TITLE
LB-5991: LKBKS - Added an external logger for SyncRestHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+executionlog.txt

--- a/Core/RestCalls/SyncRestHandler.php
+++ b/Core/RestCalls/SyncRestHandler.php
@@ -27,10 +27,11 @@ class SyncRestHandler extends RestHandler
 	 *
 	 * @param ServiceContext $context The context
 	 */
-	public function SyncRestHandler($context)
+	public function SyncRestHandler($context, $logger = null)
 	{
 		parent::__construct($context);
 		$this->context = $context;
+		$this->logger = $logger;
 
 		return $this;
 	}
@@ -292,6 +293,7 @@ class SyncRestHandler extends RestHandler
       //Logging
 			list($response_code, $response_xml, $response_headers) = $this->GetOAuthResponseHeaders($oauth);
 			$this->RequestLogging->LogPlatformRequests($response_xml, $requestUri, $response_headers, FALSE);
+			$this->externalLog('error', $response_xml, $requestUri, $response_headers);
 			//Save Error on faultHandler
 			$this->faultHandler = new FaultHandler($this->context, $e);
 			//echo "Response: {$response_code} - {$response_xml} \n";
@@ -310,6 +312,19 @@ class SyncRestHandler extends RestHandler
 		return array($response_code,$response_xml);
 	}
 
+	private function externalLog($level, $body, $uri, $headers)
+	{
+		if (!method_exists($this->logger, $level)) {
+			return false;
+		}
+		$this->logger->$level(array(
+			'level' => $level,
+			'type' => $this->context->serviceType,
+			'request' => $uri,
+			'response' => $body,
+			'headers' => $headers
+		));
+	}
         /**
          * Accept anything if content type is not XML or Json
          * @param type $value

--- a/DataService/DataService.php
+++ b/DataService/DataService.php
@@ -87,7 +87,7 @@ class DataService {
      *
      * @param ServiceContext $serviceContext IPP Service Context
      */
-    public function __construct($serviceContext) {
+    public function __construct($serviceContext, $logger = null) {
         if (NULL == $serviceContext) {
             throw new InvalidArgumentException('Resources.ServiceContextCannotBeNull');
         }
@@ -98,11 +98,12 @@ class DataService {
 
         //ServiceContextValidation(serviceContext);
         $this->serviceContext = $serviceContext;
+        $this->logger = $logger;
 
         $this->setupSerializers();
         $this->useMinorVersion();
 
-        $this->restHandler = new SyncRestHandler($serviceContext);
+        $this->restHandler = new SyncRestHandler($serviceContext, $this->logger);
 
         // Set the Service type to either QBO or QBD by calling a method.
         $this->serviceContext->UseDataServices();
@@ -251,7 +252,7 @@ class DataService {
           break;
         }
 
-      //$restRequestHandler = new SyncRestHandler($this->serviceContext);
+      //$restRequestHandler = new SyncRestHandler($this->serviceContext, $this->logger);
       $restRequestHandler = $this->getRestHandler();
       list($responseCode, $responseBody) = $restRequestHandler->GetResponse($requestParameters, $httpsPostBody, NULL);
       $faultHandler = $restRequestHandler->getFaultHandler();
@@ -569,7 +570,7 @@ class DataService {
         $httpsPostBody = $query;
 
         $requestParameters = $this->getPostRequestParameters($httpsUri, $httpsContentType);
-        $restRequestHandler = new SyncRestHandler($this->serviceContext);
+        $restRequestHandler = new SyncRestHandler($this->serviceContext, $this->logger);
         list($responseCode, $responseBody) = $restRequestHandler->GetResponse($requestParameters, $httpsPostBody, NULL);
         $faultHandler = $restRequestHandler->getFaultHandler();
         if(isset($faultHandler)){
@@ -619,7 +620,7 @@ class DataService {
         $httpsPostBody = "select * from $entityName startPosition $pageNumber maxResults $pageSize";
 
         $requestParameters = $this->getPostRequestParameters($httpsUri, $httpsContentType);
-        $restRequestHandler = new SyncRestHandler($this->serviceContext);
+        $restRequestHandler = new SyncRestHandler($this->serviceContext, $this->logger);
         list($responseCode, $responseBody) = $restRequestHandler->GetResponse($requestParameters, $httpsPostBody, NULL);
         $faultHandler = $restRequestHandler->getFaultHandler();
         if(isset($faultHandler)){
@@ -669,7 +670,7 @@ class DataService {
 
         // Creates request parameters
         $requestParameters = $this->getGetRequestParameters($uri, CoreConstants::CONTENTTYPE_APPLICATIONXML);
-        $restRequestHandler = new SyncRestHandler($this->serviceContext);
+        $restRequestHandler = new SyncRestHandler($this->serviceContext, $this->logger);
 
         list($responseCode, $responseBody) = $restRequestHandler->GetResponse($requestParameters, NULL, NULL);
         $faultHandler = $restRequestHandler->getFaultHandler();
@@ -911,7 +912,7 @@ class DataService {
      */
     protected function getRestHandler()
     {
-        return new SyncRestHandler($this->serviceContext);
+        return new SyncRestHandler($this->serviceContext, $this->logger);
     }
 
     /**


### PR DESCRIPTION
* These changes allow the use of an external logger with the QBO SDK

* We pass the external logger as a parameter to the DataService
  constructor, and use the same parameter when creating SyncRestHandler
  instances

* In SyncRestHandler instances, created a new method externalLog()
  which uses the external logger to log the request/response/headers
  of the QBO API calls